### PR TITLE
Fix ErrorException during artisan module:crud

### DIFF
--- a/src/Console/ModuleCrud.php
+++ b/src/Console/ModuleCrud.php
@@ -92,6 +92,7 @@ class ModuleCrud extends Command
             '_camel_case_'               => ucfirst(camel_case($table)),
             '_camel_casePlural_'         => ucfirst(str_plural(camel_case($table))),
             'template_source'            => __DIR__.'/../Templates/CRUD/',
+            'tests_generated'            => 'integration,service,repository',
         ];
 
         $appConfig = $config;


### PR DESCRIPTION
The following error occurs while running php artisan module:crud ModuleName

```
ErrorException: Undefined index: tests_generated in /home/vagrant/laravel-project/vendor/yab/laracogs/src/Generators/CrudGenerator.php:188
```

With this new line the tests are now generated for the crud module.
