### PR TITLE
Highlight exact menu entry

### DIFF
--- a/src/Assets/js/dashboard.js
+++ b/src/Assets/js/dashboard.js
@@ -5,7 +5,7 @@
 */
 
 $('.nav-sidebar li').each(function(){
-    if ($('.page-header').text().toLowerCase().trim().indexOf($(this).children('a').text().toLowerCase().trim()) >= 0) {
+    if ($('.page-header').text().toLowerCase().trim() == ($(this).children('a').text().toLowerCase().trim())) {
         $(this).addClass('active');
     }
 });


### PR DESCRIPTION
in the backend, many left menu entries would be highlighted
as "active" if the tile of the current page matches more elements.
This commit will fix this, highlighting only the entry that matches
_exactly_ the page title
