### PR TITLE
Change view loading method

### DIFF
--- a/src/Console/ModuleCrud.php
+++ b/src/Console/ModuleCrud.php
@@ -193,7 +193,8 @@ class ModuleCrud extends Command
      * Generate the provider file.
      *
      * @param  array $config
-     * @return boolean
+     *
+     * @return bool
      */
     public function makeTheProvider($config)
     {

--- a/src/QuarxProvider.php
+++ b/src/QuarxProvider.php
@@ -30,7 +30,7 @@ class QuarxProvider extends ServiceProvider
 
         $theme = Config::get('quarx.frontend-theme', 'default');
 
-        View::addNamespace('quarx', __DIR__.'/Views');
+        $this->loadViewsFrom(__DIR__.'/Views', 'quarx');
         View::addLocation(base_path('resources/themes/'.$theme));
         View::addNamespace('quarx-frontend', base_path('resources/themes/'.$theme));
 


### PR DESCRIPTION
Adding the view namespace via "loadViewsFrom" method makes the backend templates overridable by adding templates to the a directory named "resources/views/vendor/quarx" https://laravel.com/docs/5.1/packages#resources
