### PR TITLE
Fix saving models from administrator interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 /node_modules
+.idea

--- a/src/Models/Blog.php
+++ b/src/Models/Blog.php
@@ -24,6 +24,18 @@ class Blog extends QuarxModel
         'translations',
     ];
 
+    protected $fillable = [
+        'title',
+        'entry',
+        'tags',
+        'is_published',
+        'seo_description',
+        'seo_keywords',
+        'url',
+        'template',
+        'published_at',
+    ];
+
     public function getEntryAttribute($value)
     {
         return new Normalizer($value);

--- a/src/Models/Event.php
+++ b/src/Models/Event.php
@@ -23,6 +23,18 @@ class Event extends QuarxModel
         'translations',
     ];
 
+    protected $fillable = [
+        'start_date',
+        'end_date',
+        'title',
+        'details',
+        'seo_description',
+        'seo_keywords',
+        'is_published',
+        'template',
+        'published_at',
+    ];
+
     public function getDetailsAttribute($value)
     {
         return new Normalizer($value);

--- a/src/Models/FAQ.php
+++ b/src/Models/FAQ.php
@@ -21,4 +21,11 @@ class FAQ extends QuarxModel
     protected $appends = [
         'translations',
     ];
+
+    protected $fillable = [
+        'question',
+        'answer',
+        'is_published',
+        'published_at',
+    ];
 }

--- a/src/Models/File.php
+++ b/src/Models/File.php
@@ -13,4 +13,16 @@ class File extends QuarxModel
     public static $rules = [
         'location' => 'required',
     ];
+
+    protected $fillable = [
+        'name',
+        'location',
+        'user',
+        'tags',
+        'details',
+        'mime',
+        'size',
+        'is_published',
+        'order',
+    ];
 }

--- a/src/Models/Image.php
+++ b/src/Models/Image.php
@@ -29,6 +29,17 @@ class Image extends QuarxModel
         'location' => 'mimes:jpeg,jpg,bmp,png,gif',
     ];
 
+    protected $fillable = [
+        'location',
+        'name',
+        'original_name',
+        'storage_location',
+        'alt_tag',
+        'title_tag',
+        'is_published',
+        'tags',
+    ];
+
     /**
      * Get the images url location.
      *

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -13,4 +13,12 @@ class Link extends QuarxModel
     public static $rules = [
         'name' => 'required',
     ];
+
+    protected $fillable = [
+        'name',
+        'external',
+        'page_id',
+        'menu_id',
+        'external_url',
+    ];
 }

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -14,4 +14,9 @@ class Menu extends QuarxModel
         'name' => 'required',
         'slug' => 'required',
     ];
+
+    protected $fillable = [
+        'name',
+        'slug',
+    ];
 }

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -24,6 +24,17 @@ class Page extends QuarxModel
         'translations',
     ];
 
+    protected $fillable = [
+        'title',
+        'url',
+        'entry',
+        'seo_description',
+        'seo_keywords',
+        'is_published',
+        'template',
+        'published_at',
+    ];
+
     public function getEntryAttribute($value)
     {
         return new Normalizer($value);

--- a/src/Models/Translation.php
+++ b/src/Models/Translation.php
@@ -12,6 +12,13 @@ class Translation extends QuarxModel
 
     public static $rules = [];
 
+    protected $fillable = [
+        'entity_id',
+        'entity_type',
+        'entity_data',
+        'language',
+    ];
+
     public function getDataAttribute()
     {
         $object = app($this->entity_type);

--- a/src/Models/Widget.php
+++ b/src/Models/Widget.php
@@ -22,4 +22,10 @@ class Widget extends QuarxModel
     protected $appends = [
         'translations',
     ];
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'content',
+    ];
 }


### PR DESCRIPTION
When I installing the Quarx and tried to crate some entity (menu, page etc) backend returned error, because $request->all() included some fields not contained in the model. Adding $fillable property in to models resolve this problem.