### PR TITLE
Ensure that the answer field for FAQs is required

### DIFF
--- a/src/Models/FAQ.php
+++ b/src/Models/FAQ.php
@@ -16,6 +16,7 @@ class FAQ extends QuarxModel
 
     public static $rules = [
         'question' => 'required',
+        'answer' => 'required',
     ];
 
     protected $appends = [


### PR DESCRIPTION
Answer field is a required field in the database