### PR TITLE
prevent php artisan route:list from failing

### DIFF
--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -15,7 +15,7 @@ class ApiController extends GrafiteCmsController
     {
         parent::construct();
 
-        $this->modelName = str_singular($request->segment(3));
+        $this->modelName = str_singular($request->segment(3) ?? '');
         if (! empty($this->modelName)) {
             $this->model = app('Grafite\Cms\Models\\'.ucfirst($this->modelName));
         }


### PR DESCRIPTION
php artisan route:list fails because of a null value in str_singular($request->segment(3)).
This change (str_singular($request->segment(3) ?? '') will check for a nuul value preventing the errors