### PR TITLE
Update cms.php

### DIFF
--- a/src/PublishedAssets/Config/cms.php
+++ b/src/PublishedAssets/Config/cms.php
@@ -117,6 +117,7 @@ return [
 
     'storage-location' => 'local', // s3, local
     'max-file-upload-size' => 6291456, // 6MB
+    'max-image-size' => 800, // width - auto height
     'preview-image-size' => 800, // width - auto height
     'cloudfront' => null, // do not include http
 


### PR DESCRIPTION
FileService.php, when saving images, looks for a declaration in config/cms of `max-image-size`, with a default to 800px:

```php
//cms/src/Services/FileService.php
118    if ($isImage) {
119            $storage = Storage::disk(Config::get('cms.storage-location', 'local'));
120            $image = $storage->get($directory.$newFileName.'.'.$extension);
121    
122            $image = InterventionImage::make($image)->resize(config('cms.max-image-size', 800), null, function ($constraint) {
123                $constraint->aspectRatio();
124            });
125
126            $imageResized = $image->stream();
127    
128            $storage->delete($directory.$newFileName.'.'.$extension);
129            $storage->put($directory.$newFileName.'.'.$extension, $imageResized->__toString());
130        }
```

this config variable is not declared, and can be confusing if trying to upload hero_images larger than 800px. Propose adding the variable to the config/cms file by default